### PR TITLE
Fix typeError: functions expect parameter to be string

### DIFF
--- a/Model/Observer/ControllerActionPostdispatch.php
+++ b/Model/Observer/ControllerActionPostdispatch.php
@@ -42,8 +42,8 @@ class ControllerActionPostdispatch extends Observer
 
         // Get customer-data
         $customer = $this->customerSession->getCustomer();
-        $customerName = trim($customer->getName());
-        $customerEmail = trim($customer->getEmail());
+        $customerName = trim((string) $customer->getName());
+        $customerEmail = trim((string) $customer->getEmail());
 
         // Correct empty values
         if (empty($customerName)) {

--- a/Model/Service/Agent.php
+++ b/Model/Service/Agent.php
@@ -102,7 +102,7 @@ class Agent
         $this->debug('Calling setNameTransaction', array($name));
 
         if ($this->functionExists('newrelic_name_transaction')) {
-            newrelic_name_transaction($name);
+            newrelic_name_transaction((string) $name);
         }
     }
 


### PR DESCRIPTION
The trim and newrelic_name_transaction functions do not accept null values. For this reason the values are casted to strings.